### PR TITLE
Arrange `POST` behaviour for SORACOM server

### DIFF
--- a/SoraCommonNet/Communicator.cs
+++ b/SoraCommonNet/Communicator.cs
@@ -43,6 +43,13 @@ namespace SoraCommonNet
             {
                 req.AddParameter(msgBody);
             }
+            else
+            {
+                if (method == HttpMethod.Post)
+                {
+                    req.AddParameter(new object[]{ });
+                }
+            }
             return req;
         }
 

--- a/SoraCommonNet/Subscriber.cs
+++ b/SoraCommonNet/Subscriber.cs
@@ -77,7 +77,6 @@ namespace SoraCommonNet
             throw new NotImplementedException();
         }
 
-        // FIXME: not tested yet
         public async Task<bool> Activate()
         {
             try
@@ -92,7 +91,6 @@ namespace SoraCommonNet
             }
         }
 
-        // FIXME: not tested yet
         public async Task<bool> Deactivate()
         {
             try
@@ -122,7 +120,6 @@ namespace SoraCommonNet
             }
         }
 
-        // FIXME: not tested yet
         public async Task<bool> EnableTermination()
         {
             try
@@ -138,7 +135,6 @@ namespace SoraCommonNet
             }
         }
 
-        // FIXME: not tested yet
         public async Task<bool> DisableTermination()
         {
             try

--- a/SoraCommonTest/Program.cs
+++ b/SoraCommonTest/Program.cs
@@ -46,6 +46,34 @@ namespace SoraCommonTest
             var subscr = await op.RetrieveSubscriber(account1FirstSubscriberImsi);
             Assert.IsNotNull(subscr);
             Assert.AreEqual(account1FirstSubscriberImsi, subscr.Imsi);
+            var originalStatus = string.Copy(subscr.Status);
+            var originalTerminationEnabled = subscr.TerminationEnabled;
+            Assert.IsTrue(await subscr.EnableTermination());
+            Assert.IsTrue(await subscr.DisableTermination());
+            switch (originalTerminationEnabled)
+            {
+                case true:
+                    Assert.IsTrue(await subscr.EnableTermination());
+                    break;
+                case false:
+                    Assert.IsTrue(await subscr.DisableTermination());
+                    break;
+            }
+            Assert.IsTrue(await subscr.Deactivate());
+            Assert.IsTrue(await subscr.Activate());
+            // restore original status
+            switch (originalStatus)
+            {
+                case "inactive":
+                    Assert.IsTrue(await subscr.Deactivate());
+                    break;
+                case "active":
+                    Assert.IsTrue(await subscr.Activate());
+                    break;
+                default:
+                    break;
+            }
+
             /*
             var subscribers = await op.ListSubscribers();
             Assert.IsNotNull(subscribers);


### PR DESCRIPTION
- Add tests for tweaking subscriber settings
- Now Subscriber APIs are partially tested
